### PR TITLE
Add where parameter to numpy.ptp

### DIFF
--- a/numpy/_core/_methods.py
+++ b/numpy/_core/_methods.py
@@ -229,10 +229,10 @@ def _std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False, *,
 
     return ret
 
-def _ptp(a, axis=None, out=None, keepdims=False):
+def _ptp(a, axis=None, out=None, keepdims=False, where=True):
     return um.subtract(
-        umr_maximum(a, axis, None, out, keepdims),
-        umr_minimum(a, axis, None, None, keepdims),
+        umr_maximum(a, axis, None, out, keepdims, _NoValue, where),
+        umr_minimum(a, axis, None, None, keepdims, _NoValue, where),
         out
     )
 

--- a/numpy/_core/fromnumeric.py
+++ b/numpy/_core/fromnumeric.py
@@ -2953,12 +2953,12 @@ def cumsum(a, axis=None, dtype=None, out=None):
     return _wrapfunc(a, 'cumsum', axis=axis, dtype=dtype, out=out)
 
 
-def _ptp_dispatcher(a, axis=None, out=None, keepdims=None):
+def _ptp_dispatcher(a, axis=None, out=None, keepdims=None, where=None):
     return (a, out)
 
 
 @array_function_dispatch(_ptp_dispatcher)
-def ptp(a, axis=None, out=None, keepdims=np._NoValue):
+def ptp(a, axis=None, out=None, keepdims=np._NoValue, where=np._NoValue):
     """
     Range of values (maximum - minimum) along an axis.
 
@@ -2997,6 +2997,10 @@ def ptp(a, axis=None, out=None, keepdims=np._NoValue):
         `ndarray`, however any non-default value will be.  If the
         sub-class' method does not implement `keepdims` any
         exceptions will be raised.
+
+    where : array_like of bool, optional
+        Elements to include in the peak-to-peak. See
+        `~numpy.ufunc.reduce` for details.
 
     Returns
     -------
@@ -3038,7 +3042,9 @@ def ptp(a, axis=None, out=None, keepdims=np._NoValue):
     """
     kwargs = {}
     if keepdims is not np._NoValue:
-        kwargs['keepdims'] = keepdims
+        kwargs["keepdims"] = keepdims
+    if where is not np._NoValue:
+        kwargs["where"] = where
     return _methods._ptp(a, axis=axis, out=out, **kwargs)
 
 

--- a/numpy/_core/fromnumeric.pyi
+++ b/numpy/_core/fromnumeric.pyi
@@ -1004,6 +1004,7 @@ def ptp(
     axis: None = None,
     out: None = None,
     keepdims: Literal[False] = ...,
+    where: _ArrayLikeBool_co = ...,
 ) -> _ScalarT: ...
 @overload
 def ptp(
@@ -1011,6 +1012,7 @@ def ptp(
     axis: _ShapeLike | None = None,
     out: None = None,
     keepdims: bool = ...,
+    where: _ArrayLikeBool_co = ...,
 ) -> Any: ...
 @overload
 def ptp(
@@ -1018,6 +1020,7 @@ def ptp(
     axis: _ShapeLike | None,
     out: _ArrayT,
     keepdims: bool = ...,
+    where: _ArrayLikeBool_co = ...,
 ) -> _ArrayT: ...
 @overload
 def ptp(
@@ -1026,6 +1029,7 @@ def ptp(
     *,
     out: _ArrayT,
     keepdims: bool = ...,
+    where: _ArrayLikeBool_co = ...,
 ) -> _ArrayT: ...
 
 @overload

--- a/numpy/_core/tests/test_numeric.py
+++ b/numpy/_core/tests/test_numeric.py
@@ -153,6 +153,11 @@ class TestNonarrayArgs:
         a = [3, 4, 5, 10, -3, -5, 6.0]
         assert_equal(np.ptp(a, axis=0), 15.0)
 
+    def test_ptp_where(self):
+        a = np.array([1, 5, 7, 0])
+        where = [True, False, True, False]
+        assert_equal(np.ptp(a, where=where), 6)
+
     def test_prod(self):
         arr = [[1, 2, 3, 4],
                [5, 6, 7, 9],


### PR DESCRIPTION
## Summary
- add optional `where` argument to `np.ptp` and its implementation
- document and type the new parameter
- test `where` filtering for `ptp`

## Testing
- `ruff check numpy/_core/_methods.py numpy/_core/fromnumeric.py numpy/_core/fromnumeric.pyi numpy/_core/tests/test_numeric.py`
- `pytest numpy/_core/tests/test_numeric.py::TestFromnumeric::test_ptp_where -q` *(fails: No module named 'numpy._core._multiarray_umath')*


------
https://chatgpt.com/codex/tasks/task_e_68b4738f8aa0833395ac69e65aa78103